### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RTMP support for [Clappr player](http://github.com/globocom/clappr). Supports bo
 Import rtmp.min.js
 
 ```javascript
-<script type="text/javascript" src="http://cdn.jsdelivr.net/clappr.rtmp/latest/rtmp.min.js">
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr-rtmp@latest/dist/rtmp.min.js">
 </script>
 ```
 and create Clappr Player adding the external plugin:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RTMP support for [Clappr player](http://github.com/globocom/clappr). Supports bo
 Import rtmp.min.js
 
 ```javascript
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr-rtmp@latest/dist/rtmp.min.js">
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/video-dev/clappr-rtmp-plugin@latest/dist/rtmp.min.js">
 </script>
 ```
 and create Clappr Player adding the external plugin:


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version. You can always find the correct link at https://www.jsdelivr.com/package/npm/clappr-rtmp.

Feel free to ping me if you have any questions regarding this change.