### PR TITLE
Fix flash in Firefox using latest Clappr (0.2.85)

### DIFF
--- a/public/flash.html
+++ b/public/flash.html
@@ -23,6 +23,7 @@
   allowfullscreen="false"
   bgcolor="#000000"
   FlashVars="playbackId=<%= playbackId %>&scaling=<%= scaling %>&bufferTime=<%= bufferTime %>&playbackType=<%= playbackType %>&startLevel=<%= startLevel %>&useAppInstance=<%= useAppInstance %>&proxyType=<%= proxyType %>&autoSwitch=<%= autoSwitch %>&switchRules=<%= switchRules %>"
+  data="<%= swfPath %>"
   src="<%= swfPath %>"
   width="100%"
   height="100%">

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ export default class RTMP extends Flash {
     get attributes() {
         return {
             'data-rtmp': '',
+            'data': this.swfPath,
             'type': 'application/x-shockwave-flash',
             'width': '100%',
             'height': '100%'
@@ -191,8 +192,6 @@ export default class RTMP extends Flash {
             if (Browser.isLegacyIE) {
                 this.$el.attr('classid', IE_CLASSID)
             }
-        } else if (Browser.isFirefox) {
-            this._setupFirefox()
         }
         this.el.id = this.cid
         var style = Styler.getStyleFor(flashStyle)


### PR DESCRIPTION
Fixes #48 .

Simply ported the fixes from https://github.com/clappr/clappr/commit/6f18eaaa4e3cea670ef293747ee402db20e468c6

Tested successfully with manual edits of dist/ using FF 57.0 and Chrome 63 on Ubuntu.

Unfortunately I don't have the environment to follow the full build process.